### PR TITLE
Replacing systemcontext with context_system::instance()

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-if (has_capability('moodle/role:manage', $systemcontext)) {
+if (has_capability('moodle/role:manage', context_system::instance())) {
     $ADMIN->add('roles', new admin_externalpage('tooleditrolesbycap',
             get_string('pluginname', 'tool_editrolesbycap'),
             new moodle_url('/admin/tool/editrolesbycap/index.php'),


### PR DESCRIPTION
In 2.6, we get a fetal error, saying $systemcontext is not set (which then throws a permission error). I'm not exactly sure why, as other setting pages seem to use it too. I've made this simple change which stops it.
